### PR TITLE
#30 Integrate bugfix to fix Paragraph Seeder

### DIFF
--- a/database/seeders/ParagraphSeeder.php
+++ b/database/seeders/ParagraphSeeder.php
@@ -7,6 +7,7 @@ use App\Models\Documents;
 use App\Models\Paragraphs;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Traversable;
 
 class ParagraphSeeder extends Seeder
 {
@@ -22,11 +23,22 @@ class ParagraphSeeder extends Seeder
         curl_close($curl);
         return $result;
     }
-    
+
     static function addParagraphs($document_url, $extractor) {
         $docs_data = json_decode(file_get_contents($document_url), true)['data'];
 
         foreach($docs_data as $doc){
+            // If entry data is a merger of metadata of multiple documents, retain the first
+            if(is_array($doc['case_number']) or ($doc['case_number'] instanceof Traversable)) {
+                $newdoc = [
+                    'case_number'   => $doc['case_number'][0],
+                    'title'         => $doc['title'][0],
+                    'date'          => $doc['date'][0],
+                    'document_href' => $doc['document_href'][0]
+                ];
+                $doc = $newdoc;
+            }
+
             $ret=Documents::updateOrCreate(
                 ['case_number' => $doc['case_number']],
                 [

--- a/database/seeders/ParagraphSeeder.php
+++ b/database/seeders/ParagraphSeeder.php
@@ -5,8 +5,8 @@ namespace Database\Seeders;
 use Carbon\Carbon;
 use App\Models\Documents;
 use App\Models\Paragraphs;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Log;
 use Traversable;
 
 class ParagraphSeeder extends Seeder
@@ -34,7 +34,8 @@ class ParagraphSeeder extends Seeder
                     'case_number'   => $doc['case_number'][0],
                     'title'         => $doc['title'][0],
                     'date'          => $doc['date'][0],
-                    'document_href' => $doc['document_href'][0]
+                    'document_href' => $doc['document_href'][0],
+                    'paragraphs'    => array_key_exists("paragraphs", $doc) ? $doc['paragraphs'] : []
                 ];
                 $doc = $newdoc;
             }
@@ -50,7 +51,7 @@ class ParagraphSeeder extends Seeder
             );
 
             $paragraphs_chunk=[];
-            if(!array_key_exists("paragraphs", $doc)) return;
+            if(!array_key_exists("paragraphs", $doc)) continue;
             $paragraphs=$doc['paragraphs'][$extractor];
             foreach($paragraphs as $para){
                 $id=(!is_null($ret['id'])) ? $ret['id'] : $ret['doc_id'];


### PR DESCRIPTION
This PR adds some bugfixes to fix `ParagraphSeeder`:

- Load paragraphs for documents with multi-valued attributes.
- Prevent return of control to the next file when a document without paragraphs is encountered.